### PR TITLE
Remove unused variable

### DIFF
--- a/src/class/PathHelpers.js
+++ b/src/class/PathHelpers.js
@@ -1,5 +1,4 @@
 const equal = require('./equal');
-const { exists } = require('grunt');
 const _ = require('lodash');
 
 class PathHelpers {


### PR DESCRIPTION
It will cause an error `Cannot find module 'grunt'` if `grunt` is not installed.