### PR TITLE
Fix: Fix automated releases (fix #9)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "name": "babel-plugin-transform-amd-to-es6",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cgkineo/babel-plugin-transform-amd-to-es6"
+  },
   "version": "1.0.1",
   "description": "Convert AMD modules to ES modules using babel",
   "homepage": "https://github.com/cgkineo/babel-plugin-transform-amd-to-es6",


### PR DESCRIPTION
Fix #9 

### Fix
* Add `repository` object to _package.json_
* Add _.npmignore_ to suppress warning: `npm warn gitignore-fallback No .npmignore file found, using .gitignore for file exclusion. Consider creating a .npmignore file to explicitly control published files.`