### PR TITLE
Chore: use shared workflow files (fix #23)

### DIFF
--- a/.github/workflows/addtomainproject.yml
+++ b/.github/workflows/addtomainproject.yml
@@ -1,5 +1,4 @@
 name: Add to main project
-
 on:
   issues:
     types:
@@ -7,13 +6,8 @@ on:
   pull_request:
     types:
       - opened
-
+  workflow_dispatch:
 jobs:
   add-to-project:
-    name: Add to main project
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/add-to-project@v0.1.0
-        with:
-          project-url: https://github.com/orgs/cgkineo/projects/3/views/1
-          github-token: ${{ secrets.ADDTOPROJECT_TOKEN }}
+    uses: cgkineo/.github/.github/workflows/addtomainproject.yml@master
+    secrets: inherit


### PR DESCRIPTION
Fixes #23

### Update
- Migrate the add-to-project workflow to the reusable, shared `addtomainproject.yml` in `cgkineo/.github`.
- Leave the existing `releases.yml` in place: this package publishes to npm via OIDC trusted publishing, which the shared releases workflow does not yet support.

Posted via collaboration with Claude Code